### PR TITLE
igprof-navigator. Don't remove /1 unless it is at the end of the url.

### DIFF
--- a/src/igprof-navigator
+++ b/src/igprof-navigator
@@ -184,7 +184,8 @@ def summary(database, out, cumulative):
   if "PATH_INFO" in os.environ and "SCRIPT_NAME" in os.environ:
     absPath = join(os.environ["SCRIPT_NAME"],
                    os.environ["PATH_INFO"].lstrip("/")).rstrip("/")
-    absPath = absPath.replace("/cumulative", "").replace("/self", "").replace("/1", "")
+    absPath = absPath.replace("/cumulative", "").replace("/self", "")
+    absPath = re.sub(r"/1$", "", absPath)
   else:
     absPath = "."
 


### PR DESCRIPTION
Fixes the problem of '/1' being removed from links.

Eg, this link
`https://cmssdt.cern.ch/SDT/cgi-bin/igprof-navigator/CMSSW_11_2_X_2020-08-06-1100/slc7_amd64_gcc820/pp36.836_RunSinglePh2017F+RunSinglePh2017F+HLTDR2_2017+RECODR2_2017reHLT_skimSinglePh_Prompt+HARVEST2017/igprof.cmsRun.741.1596725220.007904/self`
should be
`https://cmssdt.cern.ch/SDT/cgi-bin/igprof-navigator/CMSSW_11_2_X_2020-08-06-1100/slc7_amd64_gcc820/pp/136.836_RunSinglePh2017F+RunSinglePh2017F+HLTDR2_2017+RECODR2_2017reHLT_skimSinglePh_Prompt+HARVEST2017/igprof.cmsRun.741.1596725220.007904/self`