### PR TITLE
Don't disable the profiling timer and don't delete the trace buffer when the start routine for the thread exits.

### DIFF
--- a/src/profile-perf.cc
+++ b/src/profile-perf.cc
@@ -107,6 +107,9 @@ enableSignalHandler(void)
 static void
 threadInit(void)
 {
+  // check if someone else has installed a signal handler
+  struct sigaction sa;
+  if (!(sa.sa_handler == SIG_IGN || sa.sa_handler == SIG_DFL)) return;
   // Enable profiling in this thread.
   enableSignalHandler();
   enableTimer();

--- a/src/profile.cc
+++ b/src/profile.cc
@@ -155,8 +155,8 @@ disposeTraceBuffer(IgProfTrace *buf)
     igprof_debug("merging profile buffer %p to master buffer %p\n",
                  (void *) buf, (void *) s_masterbuf);
     s_masterbuf->mergeFrom(*buf);
-    allTraceBuffers().erase(buf);
-    delete buf;
+//    allTraceBuffers().erase(buf);
+//    delete buf;
   }
 }
 
@@ -836,10 +836,10 @@ threadWrapper(void *arg)
 		   (unsigned long) pthread_self(),
 		   (void *) start_routine, start_arg);
 
-    itimerval stopped = { { 0, 0 }, { 0, 0 } };
-    setitimer(ITIMER_PROF, &stopped, 0);
-    setitimer(ITIMER_VIRTUAL, &stopped, 0);
-    setitimer(ITIMER_REAL, &stopped, 0);
+//    itimerval stopped = { { 0, 0 }, { 0, 0 } };
+//    setitimer(ITIMER_PROF, &stopped, 0);
+//    setitimer(ITIMER_VIRTUAL, &stopped, 0);
+//    setitimer(ITIMER_REAL, &stopped, 0);
   }
   return ret;
 }


### PR DESCRIPTION
This fixes the issue with Igprof undercounting the time spent in routine when using TBB resumable tasks.
The problem seems to occur when the start routine of a thread exits. Igprof disable the profiling timer on the thread, merges and then deletes the trace buffer for the thread. With debugging enable this Igprof trace gave a hint to the problem
```
2021-04-30 16:48:39.289244: I tensorflow/core/platform/profile_utils/cpu_utils.cc:112] CPU Frequency: 3600000000 Hz
*** IgProf(15948, 1619794119.368): captured thread id 0x7f4affdfd700 for profiling (0x7f4c61810540(0x7f4bb525d300))
*** IgProf(15948, 1619794119.368): leaving thread id 0x7f4affdfd700 from profiling (0x7f4c61810540(0x7f4bb525d300))
*** IgProf(15948, 1619794119.368): merging profile buffer 0x7f4aff000000 to master buffer 0x7f4ca4dc6660
```